### PR TITLE
feature: add timeout for register to prevent infinite waiting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,11 @@ class Softphone extends EventEmitter {
 
   public async register() {
     if (!this.connected) {
-      await waitFor({ interval: 100, condition: () => this.connected });
+      const isConnected = await waitFor({ interval: 100, times: 100, condition: () => this.connected });
+
+      if (!isConnected) {
+        throw new Error('Failed to register: timeout')
+      }
     }
     const sipRegister = async () => {
       const fromTag = uuid();


### PR DESCRIPTION
### Summary

Added a timeout for the registration process to prevent indefinite waiting when the registration message is not received.

### Context

Previously, if the app didn’t receive a registration message, it could wait indefinitely. In production, we encountered a situation where the app crashed due to an unrelated error. Upon restart, the softphone failed to register for an extended period, leaving the system non-functional until the server was manually restarted.

### Change

With this update, if registration doesn’t complete within the specified timeout, the server will automatically restart instead of waiting indefinitely. This ensures that the softphone can recover and re-register properly without manual intervention.